### PR TITLE
Fix <title> from SVG replacing page <title>

### DIFF
--- a/vendor/assets/javascripts/jquery.pjax.js
+++ b/vendor/assets/javascripts/jquery.pjax.js
@@ -680,8 +680,8 @@ function extractContainer(data, xhr, options) {
     return obj
 
   // If there's a <title> tag in the header, use it as
-  // the page's title.
-  obj.title = findAll($head, 'title').last().text()
+  // the page's title. Ignore tags nested in a <svg> tag.
+  obj.title = findAll($head, ':not(svg) > title').last().text()
 
   if (options.fragment) {
     var $fragment = $body


### PR DESCRIPTION
If a PJAX response contains an embedded `<svg>` with `<title>` tag inside it, this prevents the SVG's title from overwriting the page's title.